### PR TITLE
Add a timer for updating the logged in icon

### DIFF
--- a/InitGui.py
+++ b/InitGui.py
@@ -7,16 +7,19 @@
 import PySide.QtCore as QtCore
 import FreeCADGui as Gui
 
-from lens_command import LensCommand, LensWorkbenchManipulator, start_mdi_tab
+from lens_command import (
+    LensCommand,
+    LensWorkbenchManipulator,
+    start_mdi_tab,
+    init_toolbar_icon,
+)
 import register_lens_handler
-
-import WorkspaceView
 
 
 Gui.addCommand("OndselLens_OndselLens", LensCommand())
 Gui.addWorkbenchManipulator(LensWorkbenchManipulator())
 
-start_mdi_tab()
 
-QtCore.QTimer.singleShot(3000, WorkspaceView.runsAfterLaunch)
+start_mdi_tab()
+init_toolbar_icon()
 register_lens_handler.register_lens_handler()

--- a/lens_command.py
+++ b/lens_command.py
@@ -1,9 +1,7 @@
 import Utils
 import WorkspaceView
-import FreeCAD
 import FreeCADGui as Gui
-from PySide import QtGui
-from PySide import QtWidgets
+from PySide import QtGui, QtWidgets
 
 
 class LensCommand:
@@ -58,3 +56,8 @@ def start_mdi_tab():
             subwindow.setWindowTitle("Ondsel Lens")
             subwindow.setWindowIcon(QtGui.QIcon(Utils.icon_ondsel_path_connected))
             subwindow.showMaximized()
+
+
+def init_toolbar_icon():
+    if WorkspaceView.wsv:
+        WorkspaceView.wsv.init_toolbar_icon()


### PR DESCRIPTION
A first attempt tried to act on QEvents after the QToolButton had been added to the toolbar. It proved to be challenging to filter the right events and then get to the actual button (you only get QWidgets, QObjects, and in some instances QAbstractAnimation objects). Additionally, the objects did not have the object names yet, so it was quite impossible to figure out when to do what.

This is a more pragmatic approach that issues a timer only at the beginning that is running every half a second to find the right button and call to update the status. It then shuts down the timer.