### PR TITLE
Ensure the Lens Addon is visible on startup

### DIFF
--- a/InitGui.py
+++ b/InitGui.py
@@ -12,6 +12,7 @@ from lens_command import (
     LensWorkbenchManipulator,
     start_mdi_tab,
     init_toolbar_icon,
+    ensure_mdi_tab,
 )
 import register_lens_handler
 
@@ -22,4 +23,5 @@ Gui.addWorkbenchManipulator(LensWorkbenchManipulator())
 
 start_mdi_tab()
 init_toolbar_icon()
+ensure_mdi_tab()
 register_lens_handler.register_lens_handler()

--- a/lens_command.py
+++ b/lens_command.py
@@ -1,7 +1,7 @@
 import Utils
 import WorkspaceView
 import FreeCADGui as Gui
-from PySide import QtGui, QtWidgets
+from PySide import QtGui, QtWidgets, QtCore
 
 
 class LensCommand:
@@ -61,3 +61,17 @@ def start_mdi_tab():
 def init_toolbar_icon():
     if WorkspaceView.wsv:
         WorkspaceView.wsv.init_toolbar_icon()
+
+
+def ensure_mdi_tab():
+    main_window = Gui.getMainWindow()
+    timer = QtCore.QTimer(main_window)
+
+    def check_mdi_tab_visible():
+        subwindow = find_subwindow(main_window)
+        if subwindow:
+            start_mdi_tab()
+            timer.stop()
+
+    timer.timeout.connect(check_mdi_tab_visible)
+    timer.start(500)


### PR DESCRIPTION
Before this change, the Start workbench was the MDI view that was visible on startup.