### PR TITLE
Improve error handling

### DIFF
--- a/APIClient.py
+++ b/APIClient.py
@@ -212,13 +212,13 @@ class APIClient:
     def _confirm_online_after_exception(self):
         self._confirm_online()
         if self.status == ConnStatus.DISCONNECTED:
-            raise APIClientOfflineException("Safely offline")
+            raise APIClientOfflineException("Disconnected from service: logged out")
 
     def _properly_throw_if_offline(self):
         if self.status == ConnStatus.DISCONNECTED:
             self._confirm_online()  # try to connect again
             if self.status == ConnStatus.DISCONNECTED:
-                raise APIClientOfflineException("Safely offline")
+                raise APIClientOfflineException("Disconnected from service: logged out")
 
     def _delete(self, endpoint, headers={}, params=None):
         headers = self._set_default_headers(headers)

--- a/APIClient.py
+++ b/APIClient.py
@@ -109,7 +109,10 @@ class APIClient:
             self.parent.set_ui_connectionStatus()
 
     def getStatus(self):
-        """gets the current connection status; this is an active check to see if really online"""
+        """
+        Gets the current connection status;
+        This is an active check to see if really online.
+        """
         self._confirm_online()
         return self.status
 
@@ -192,9 +195,12 @@ class APIClient:
         return headers
 
     def _confirm_online(self):
-        """calls lens api root to simply check if online. if not online, updates status"""
+        """
+        Calls lens api root to simply check if online.
+        If not online, updates status.
+        """
         try:
-            response = requests.get(f"{self.base_url}/")
+            requests.get(f"{self.base_url}/")
             if self.is_logged_in():
                 self.setStatus(ConnStatus.CONNECTED)
             else:
@@ -896,7 +902,7 @@ class APIHelper:
             return data
 
 
-class API_Call_Result(Enum):
+class APICallResult(Enum):
     OK = 1  # all is good
     DISCONNECTED = 2  # all is good but not online
     NOT_LOGGED_IN = 3  # not logged in, so _this_ query is not possible
@@ -918,27 +924,25 @@ def fancy_handle(func):
     make sure you are doing "result = fancy_handle(joe)" not
     "result = fancy_handle(joe())"
 
-    Returns an API_Call_Result enum value. It is expected that the caller
+    Returns an APICallResult enum value. It is expected that the caller
     handles all the possible return states.
     """
     try:
         func()
-        return API_Call_Result.OK
-    except APIClientOfflineException as e:
-        return API_Call_Result.DISCONNECTED
-    except APIClientLoggedOutException as e:
-        return API_Call_Result.NOT_LOGGED_IN
+        return APICallResult.OK
+    except APIClientOfflineException:
+        return APICallResult.DISCONNECTED
+    except APIClientLoggedOutException:
+        return APICallResult.NOT_LOGGED_IN
     except APIClientRequestException as e:
         logger.error(e)
-        return API_Call_Result.GENERAL_ERROR
+        return APICallResult.GENERAL_ERROR
     except APIClientAuthenticationException as e:
         logger.error(e)
-        return API_Call_Result.PERMISSION_ISSUE
+        return APICallResult.PERMISSION_ISSUE
     except APIClientException as e:
         logger.error(e)
-        return API_Call_Result.GENERAL_ERROR
+        return APICallResult.GENERAL_ERROR
     except Exception as e:
         logger.error(e)
-        return API_Call_Result.GENERAL_ERROR
-    self.set_ui_connectionStatus()
-    return True
+        return APICallResult.GENERAL_ERROR

--- a/DataModels.py
+++ b/DataModels.py
@@ -14,9 +14,10 @@ from PySide.QtGui import QStandardItemModel, QStandardItem
 
 import FreeCAD
 
+from APIClient import fancy_handle, APICallResult
+
 
 CACHE_PATH = FreeCAD.getUserCachePath() + "Ondsel-Lens/"
-p = FreeCAD.ParamGet("User parameter:BaseApp/Ondsel")
 
 
 class WorkspaceListModel(QAbstractListModel):
@@ -46,12 +47,12 @@ class WorkspaceListModel(QAbstractListModel):
         self.api = api
 
     def refreshModel(self):
-        # raises an APIClientException
-        self.beginResetModel()
-        if self.api is not None and self.api.is_logged_in():
-            # the user may be disconnected
+        def try_get_workspaces_connected():
             self.workspaces = self.api.getWorkspaces()
 
+        self.beginResetModel()
+        api_result = fancy_handle(try_get_workspaces_connected)
+        if api_result == APICallResult.OK:
             self.save()
         else:
             self.load()

--- a/Utils.py
+++ b/Utils.py
@@ -37,6 +37,8 @@ ACCEL = "Ctrl+L"
 NAME_COMMAND_START = "Start_Start"
 LENS_TOOLBARITEM_TEXT = "Ondsel Lens Addon"
 
+SIZE_PIXMAP = 128
+
 
 class FreeCADHandler(logging.Handler):
     def __init__(self):
@@ -126,7 +128,9 @@ def extract_thumbnail(file_path):
                 pixmap = QPixmap()
                 pixmap.loadFromData(thumbnail_data)
 
-                return pixmap.scaled(128, 128, Qt.AspectRatioMode.KeepAspectRatio)
+                return pixmap.scaled(
+                    SIZE_PIXMAP, SIZE_PIXMAP, Qt.AspectRatioMode.KeepAspectRatio
+                )
 
         except (zipfile.BadZipFile, KeyError):
             # Handle the case where the thumbnail file doesn't exist

--- a/Workspace.py
+++ b/Workspace.py
@@ -226,7 +226,6 @@ class WorkspaceModel(QAbstractListModel):
 
     def upload(self, fileName, fileId=None, message=""):
         # Default action is to not upload anything
-        logger.debug("WorkspaceModel.upload()")
         pass
 
     def isEmptyDirectory(self, index):
@@ -286,7 +285,6 @@ class WorkspaceModel(QAbstractListModel):
         return [fi.name for fi in localDirs + localFiles]
 
     def createDir(self, dir):
-        logger.debug("WorkspaceModel.createDir()")
         fullPath = Utils.joinPath(self.getFullPath(), dir)
         if not os.path.exists(fullPath):
             os.makedirs(fullPath)
@@ -405,7 +403,6 @@ class ServerWorkspaceModel(WorkspaceModel):
         that reflect the status of the server and local file system.
 
         """
-        logger.debug("ServerWorkspaceModel.refreshModel()")
 
         self.clearModel()
 
@@ -474,7 +471,6 @@ class ServerWorkspaceModel(WorkspaceModel):
         #     self.uploadUntrackedFiles()
 
     def data(self, index, role=Qt.DisplayRole):
-        # logger.debug("ServerWorkspaceModel.data()")
         if not index.isValid():
             return None
         file_item = self.files[index.row()]
@@ -524,18 +520,14 @@ class ServerWorkspaceModel(WorkspaceModel):
         return None
 
     def openDirectory(self, index):
-        logger.debug("ServerWorkspaceModel.openDirectory()")
-
         file_item = self.files[index.row()]
         self.subPath = Utils.joinPath(self.subPath, file_item.name)
         # push the directory to the stack
         if file_item.serverFileDict.get("_id"):
             # the server knows about this directory
-            logger.debug("  pushing serverFileDict to the currentDirectory")
             self.currentDirectory.append(file_item.serverFileDict)
         else:
             # the server needs to know about this directory
-            logger.debug("  creating a directory")
             id = None
             fancy_handle(lambda: self.createDir(file_item.name))
             # ignore the result
@@ -577,7 +569,6 @@ class ServerWorkspaceModel(WorkspaceModel):
         It assumes that the directory is empty.  It should not call
         refreshModel because it is combined with a call to super().
         """
-        logger.debug("ServerWorkspaceModel.deleteDirectory()")
         super().deleteDirectory(index, NO_REFRESH)
         fileItem = self.files[index.row()]
         if fileItem.serverFileDict and "_id" in fileItem.serverFileDict:
@@ -600,7 +591,6 @@ class ServerWorkspaceModel(WorkspaceModel):
 
     def deleteFileLocally(self, index):
         """Delete a file on the local filesystem."""
-        logger.debug("ServerWorkspaceModel.deleteFileLocally()")
         super().deleteFile(index)
 
     def deleteFile(self, index):
@@ -608,7 +598,6 @@ class ServerWorkspaceModel(WorkspaceModel):
 
         This function assumes that the files have been removed locally.
         """
-        logger.debug("ServerWorkspaceModel.deleteFile()")
         file_item = self.files[index.row()]
 
         id = file_item.serverFileDict["_id"]
@@ -724,7 +713,6 @@ class ServerWorkspaceModel(WorkspaceModel):
                 self.apiClient.createModel(fileId)
 
     def openParentFolder(self):
-        logger.debug("ServerWorkspaceModel.openParentFolder()")
         self.subPath = os.path.dirname(self.subPath)
         self.currentDirectory.pop()
         self.refreshModel()
@@ -743,7 +731,6 @@ class ServerWorkspaceModel(WorkspaceModel):
         return {k: self.workspace[k] for k in ("_id", "name", "refName", "open")}
 
     def createDir(self, nameDirectory):
-        logger.debug("ServerWorkspaceModel.createDir()")
         # raises an APIClientException
         currentDir = self.currentDirectory[-1]
         workspace = self.summarizeWorkspace()

--- a/Workspace.py
+++ b/Workspace.py
@@ -603,7 +603,7 @@ class ServerWorkspaceModel(WorkspaceModel):
                 and fi.serverFileDict["_id"] == fileId
             ):
                 return fi
-        logger.error("Cannot find the correct fileId")
+        # we may be disconnected
         return None
 
     def downloadFile(self, fileItem):

--- a/Workspace.py
+++ b/Workspace.py
@@ -107,7 +107,6 @@ class WorkspaceModel(QAbstractListModel):
         self.endResetModel()
 
     def refreshModel(self):
-        logger.debug("WorkspaceModel.refreshModel()")
         self.clearModel()
         if not os.path.isdir(self.path):
             self.files = []

--- a/WorkspaceView.py
+++ b/WorkspaceView.py
@@ -905,14 +905,9 @@ class WorkspaceView(QtWidgets.QScrollArea):
         if subPath == "":
             self.leaveWorkspace()
         else:
-
-            def tryOpenParent():
-                self.currentWorkspaceModel.openParentFolder()
-                self.setWorkspaceNameLabel()
-                self.hideFileDetails()
-
-            # self.handle(tryOpenParent)
-            tryOpenParent()
+            self.currentWorkspaceModel.openParentFolder()
+            self.setWorkspaceNameLabel()
+            self.hideFileDetails()
 
     def handle_request(self, func):
         """Handle a function that raises an exception from requests."""
@@ -1025,14 +1020,8 @@ class WorkspaceView(QtWidgets.QScrollArea):
         self.form.workspaceNameLabel.setText(workspacePath)
 
     def fileListDoubleClicked(self, index):
-        logger.debug("fileListDoubleClicked()")
-
-        def tryOpenFile():
-            self.openFile(index)
-            self.setWorkspaceNameLabel()
-
-        # self.handle(tryOpenFile)
-        tryOpenFile()
+        self.openFile(index)
+        self.setWorkspaceNameLabel()
 
     def linksListDoubleClicked(self, index):
         model = self.form.linksView.model()

--- a/WorkspaceView.py
+++ b/WorkspaceView.py
@@ -52,7 +52,7 @@ from APIClient import (
     APIClientTierException,
     APIClientRequestException,
     ConnStatus,
-    API_Call_Result,
+    APICallResult,
     fancy_handle,
 )
 from Workspace import (
@@ -2218,11 +2218,11 @@ class WorkspaceView(QtWidgets.QScrollArea):
                 viewBookmarks.expandAll()
 
             api_result = fancy_handle(tryRefresh)
-            if api_result == API_Call_Result.OK:
+            if api_result == APICallResult.OK:
                 self.form.bookmarkStatusLabel.setText("")
-            elif api_result == API_Call_Result.DISCONNECTED:
+            elif api_result == APICallResult.DISCONNECTED:
                 self.form.bookmarkStatusLabel.setText("offline")
-            elif api_result == API_Call_Result.NOT_LOGGED_IN:
+            elif api_result == APICallResult.NOT_LOGGED_IN:
                 self.form.bookmarkStatusLabel.setText(
                     "you must be logged in to see bookmarks"
                 )

--- a/WorkspaceView.py
+++ b/WorkspaceView.py
@@ -1181,7 +1181,21 @@ class WorkspaceView(QtWidgets.QScrollArea):
                 else:
                     refreshUI()
 
-        self.handle(trySetVersion)
+        api_result = fancy_handle(trySetVersion)
+        if api_result == APICallResult.OK:
+            pass
+        elif api_result == APICallResult.DISCONNECTED:
+            self.hideLinkVersionDetails()
+            logger.warning("Disconnected from server.")
+        elif api_result == APICallResult.NOT_LOGGED_IN:
+            # this should not happen as the user should not have access to
+            # the share links while logged out.
+            self.hideLinkVersionDetails()
+            logger.error("Not logged in, share link has not been updated")
+        else:
+            # this should really not happen
+            self.hideLinkVersionDetails()
+            logger.error("Unknown error")
 
     def updateThumbnail(self, fileItem):
         fileName = fileItem.name

--- a/WorkspaceView.py
+++ b/WorkspaceView.py
@@ -52,7 +52,7 @@ from APIClient import (
     APIClientException,
     APIClientAuthenticationException,
     # APIClientConnectionError,
-    APIClientTierException,
+    # APIClientTierException,
     # APIClientRequestException,
     ConnStatus,
     APICallResult,
@@ -794,21 +794,28 @@ class WorkspaceView(QtWidgets.QScrollArea):
         name = self.api.getNameUser()
         menu = self.guestMenu
         icon = self.ondselIconDisconnected
+
         if self.toolBarItemAction is None:
             self.find_our_toolbaritem_action()
-        if status == ConnStatus.CONNECTED:
-            icon = self.ondselIcon
+
+        if status == ConnStatus.CONNECTED or status == ConnStatus.DISCONNECTED:
             menu = self.userMenu
             login_data = self.get_login_data()
             user = login_data.get("user", {})
             users_name = user.get("name", "?")
             users_username = user.get("username", "?")
-            status_txt = f"Logged in as {users_name} [<code>{users_username}</code>]"
+            if status == ConnStatus.CONNECTED:
+                icon = self.ondselIcon
+                status_txt = (
+                    f"Logged in as {users_name} [<code>{users_username}</code>]"
+                )
+            elif status == ConnStatus.DISCONNECTED:
+                status_txt = "No Network Service"
+                icon = self.ondselIconDisconnected
         elif status == ConnStatus.LOGGED_OUT:
             icon = self.ondselIconLoggedOut
             status_txt = "Logged Out"
-        elif status == ConnStatus.DISCONNECTED:
-            status_txt = "No Network Service"
+
         return status, status_txt, name, menu, icon
 
     def set_ui_connectionStatus(self):

--- a/WorkspaceView.py
+++ b/WorkspaceView.py
@@ -1037,17 +1037,17 @@ class WorkspaceView(QtWidgets.QScrollArea):
             elif api_result == APICallResult.DISCONNECTED:
                 self.hideLinkVersionDetails()
                 logger.warning(
-                    "Disconnected from server, share link has not been updated"
+                    "Disconnected from server.  Share link has not been updated."
                 )
             elif api_result == APICallResult.NOT_LOGGED_IN:
                 # this should not happen as the user should not have access to
                 # the share links while logged out.
                 self.hideLinkVersionDetails()
-                logger.error("Not logged in, share link has not been updated")
+                logger.error("Not logged in. Share link has not been updated.")
             else:
                 # this should really not happen
                 self.hideLinkVersionDetails()
-                logger.error("Unknown error")
+                logger.error("Unknown error updating share links.")
 
     # ####
     # Downloading files
@@ -1191,11 +1191,11 @@ class WorkspaceView(QtWidgets.QScrollArea):
             # this should not happen as the user should not have access to
             # the share links while logged out.
             self.hideLinkVersionDetails()
-            logger.error("Not logged in, share link has not been updated")
+            logger.error("Not logged in.")
         else:
             # this should really not happen
             self.hideLinkVersionDetails()
-            logger.error("Unknown error")
+            logger.error("Unknown error downloading version")
 
     def updateThumbnail(self, fileItem):
         fileName = fileItem.name
@@ -1430,7 +1430,18 @@ class WorkspaceView(QtWidgets.QScrollArea):
                 FILENAME_SYS_CFG,
             )
 
-        self.handle(tryStorePrefs)
+        api_result = fancy_handle(tryStorePrefs)
+        if api_result == APICallResult.OK:
+            pass
+        elif api_result == APICallResult.DISCONNECTED:
+            logger.warning("Disconnected from server.  No preferences stored.")
+        elif api_result == APICallResult.NOT_LOGGED_IN:
+            # this should not happen as the user should not have access to
+            # the share links while logged out.
+            logger.error("Not logged in.  No preferences stored.")
+        else:
+            # this should really not happen
+            logger.error("Unknown error storing preferences")
 
     def convertParam(self, type, paramGroup, value):
         if type == "FCBool":
@@ -1633,7 +1644,18 @@ class WorkspaceView(QtWidgets.QScrollArea):
             if not result:
                 logger.info(f"Organization {nameOrg} has no preferences stored.")
 
-        self.handle(tryLoadPrefs)
+        api_result = fancy_handle(tryLoadPrefs)
+        if api_result == APICallResult.OK:
+            pass
+        elif api_result == APICallResult.DISCONNECTED:
+            logger.warning("Disconnected from server.  No preferences downloaded.")
+        elif api_result == APICallResult.NOT_LOGGED_IN:
+            # this should not happen as the user should not have access to
+            # the organization preferences while logged out.
+            logger.error("Not logged in.  No preferences downloaded.")
+        else:
+            # this should really not happen
+            logger.error("Unknown error downloading preferences")
 
     def downloadOndselDefaultPrefs(self):
         def tryLoadPrefs():
@@ -1641,7 +1663,18 @@ class WorkspaceView(QtWidgets.QScrollArea):
             if not result:
                 logger.error("No default preferences stored")
 
-        self.handle(tryLoadPrefs)
+        api_result = fancy_handle(tryLoadPrefs)
+        if api_result == APICallResult.OK:
+            pass
+        elif api_result == APICallResult.DISCONNECTED:
+            logger.warning("Disconnected from server.  No preferences downloaded.")
+        elif api_result == APICallResult.NOT_LOGGED_IN:
+            # this should not happen as the user should not have access to this
+            # menu item
+            logger.error("Not logged in.  No preferences downloaded.")
+        else:
+            # this should really not happen
+            logger.error("Unknown error downloading preferences")
 
     # ####
     # Directory deletion

--- a/WorkspaceView.py
+++ b/WorkspaceView.py
@@ -14,9 +14,6 @@ import requests
 import uuid
 import base64
 import webbrowser
-
-# import logging
-
 import random
 import math
 
@@ -51,9 +48,6 @@ from APIClient import (
     APIClient,
     APIClientException,
     APIClientAuthenticationException,
-    # APIClientConnectionError,
-    # APIClientTierException,
-    # APIClientRequestException,
     ConnStatus,
     APICallResult,
     fancy_handle,
@@ -854,14 +848,6 @@ class WorkspaceView(QtWidgets.QScrollArea):
         self.currentWorkspaceModel = ServerWorkspaceModel(
             self.current_workspace, apiClient=self.api
         )
-        # subPath = ""
-        # if hasattr(self, "currentWorkspaceModel") and self.currentWorkspaceModel:
-        #     subPath = self.currentWorkspaceModel.subPath
-        # self.currentWorkspaceModel = LocalWorkspaceModel(
-        #     self.current_workspace, subPath=subPath
-        # )
-        # I probably need to do something with the subpath
-
         self.setWorkspaceNameLabel()
         self.form.fileList.setModel(self.currentWorkspaceModel)
         self.switchView()
@@ -999,7 +985,6 @@ class WorkspaceView(QtWidgets.QScrollArea):
 
         throws an APIClientException
         """
-        logger.debug("openFile")
         wsm = self.currentWorkspaceModel
         fileItem = wsm.data(index)
         if fileItem.is_folder:
@@ -1181,6 +1166,8 @@ class WorkspaceView(QtWidgets.QScrollArea):
                     self.updateThumbnail(refreshedFileItem)
                 else:
                     refreshUI()
+
+        self.handle_api_call(trySetVersion, "Failed to download version.")
 
     def updateThumbnail(self, fileItem):
         fileName = fileItem.name
@@ -1740,22 +1727,18 @@ class WorkspaceView(QtWidgets.QScrollArea):
         Interacts with the API.
         """
 
-        def tryUpload():
-            wsm = self.currentWorkspaceModel
-            if fileId:
-                # updating an existing version
-                wsm.upload(fileName, fileId, message)
-            else:
-                # initial commit
-                wsm.upload(fileName)
-            wsm.refreshModel()
-            if self.form.versionsComboBox.isVisible():
-                model = self.form.versionsComboBox.model()
-                model.refreshModel(fileItem)
-                self.form.versionsComboBox.setCurrentIndex(model.getCurrentIndex())
-                logger.debug("versionComboBox setCurrentIndex")
-
-        tryUpload()
+        wsm = self.currentWorkspaceModel
+        if fileId:
+            # updating an existing version
+            wsm.upload(fileName, fileId, message)
+        else:
+            # initial commit
+            wsm.upload(fileName)
+        wsm.refreshModel()
+        if self.form.versionsComboBox.isVisible():
+            model = self.form.versionsComboBox.model()
+            model.refreshModel(fileItem)
+            self.form.versionsComboBox.setCurrentIndex(model.getCurrentIndex())
 
     def enterCommitMessage(self):
         dialog = EnterCommitMessageDialog()
@@ -2042,6 +2025,7 @@ class WorkspaceView(QtWidgets.QScrollArea):
     def refreshModel(self):
         if self.current_workspace is not None:
             self.currentWorkspaceModel.refreshModel()
+            self.hideLinkVersionDetails()
         else:
             self.workspacesModel.refreshModel()
 

--- a/WorkspaceView.py
+++ b/WorkspaceView.py
@@ -2025,7 +2025,8 @@ class WorkspaceView(QtWidgets.QScrollArea):
     def refreshModel(self):
         if self.current_workspace is not None:
             self.currentWorkspaceModel.refreshModel()
-            self.hideLinkVersionDetails()
+            if not self.is_connected():
+                self.hideLinkVersionDetails()
         else:
             self.workspacesModel.refreshModel()
 

--- a/WorkspaceView.py
+++ b/WorkspaceView.py
@@ -684,7 +684,7 @@ class WorkspaceView(QtWidgets.QScrollArea):
                     p.SetString("loginData", json.dumps(loginData))
                     self.set_ui_connectionStatus()
                     self.leaveWorkspace()
-                    self.handle(self.workspacesModel.refreshModel)
+                    self.workspacesModel.refreshModel()
                     self.switchView()
                     # Set a timer to logout when token expires.  since we've
                     # just received the access token, it is very unlikely that

--- a/views/ondsel_promotions_view.py
+++ b/views/ondsel_promotions_view.py
@@ -6,7 +6,7 @@ from PySide.QtCore import Qt
 from delegates.promotion_delegate import PromotionDelegate
 from models.promotion import PromotionListModel, Promotion
 from qflowview.qflowview import QFlowView
-from APIClient import fancy_handle, API_Call_Result
+from APIClient import fancy_handle, APICallResult
 
 
 class OndselPromotionsView(QFlowView):
@@ -36,12 +36,12 @@ class OndselPromotionsView(QFlowView):
 
         QApplication.setOverrideCursor(QCursor(Qt.WaitCursor))
         api_result = fancy_handle(get_promoted_items)
-        if api_result == API_Call_Result.OK:
+        if api_result == APICallResult.OK:
             self.promotionListModel.promotion_list = promotions
             self.parent.form.ondselStartStatusLabel.setText("")
             self.promotionListModel.layoutChanged.emit()
 
-        elif api_result == API_Call_Result.DISCONNECTED:
+        elif api_result == APICallResult.DISCONNECTED:
             self.parent.form.ondselStartStatusLabel.setText("off-line")
             self.promotionListModel.promotion_list = []
             self.promotionListModel.layoutChanged.emit()

--- a/views/search_results_view.py
+++ b/views/search_results_view.py
@@ -4,7 +4,7 @@ from PySide.QtGui import (
     QCursor,
 )
 from qflowview.qflowview import QFlowView
-from APIClient import fancy_handle, API_Call_Result
+from APIClient import fancy_handle, APICallResult
 
 from models.curation import CurationListModel
 from delegates.search_result_delegate import SearchResultDelegate
@@ -45,7 +45,7 @@ class SearchResultsView(QFlowView):
 
         QApplication.setOverrideCursor(QCursor(Qt.WaitCursor))
         api_result = fancy_handle(do_search)
-        if api_result == API_Call_Result.OK:
+        if api_result == APICallResult.OK:
             self.curationListModel.curation_list = resulting_curations
             if len(resulting_curations) == 0:
                 self.parent.form.searchResultMessageLabel.setText("no results")
@@ -53,7 +53,7 @@ class SearchResultsView(QFlowView):
                 self.parent.form.searchResultMessageLabel.setText("")
                 self.curationListModel.layoutChanged.emit()
 
-        elif api_result == API_Call_Result.DISCONNECTED:
+        elif api_result == APICallResult.DISCONNECTED:
             self.parent.form.searchResultMessageLabel.setText("offline")
             self.curationListModel.curation_list = []
             self.curationListModel.layoutChanged.emit()


### PR DESCRIPTION
Makes use of `fancy_handle` to improve disconnect errors. It also contains a small refactoring, see the PEP8 commit.

The local workspace model does not exist anymore and the logic for that is divided between the superclass WorkspaceModel and ServerWorkspaceModel. This effectively allows us to do more fine-grained error checking without us requiring to switch to the LocalWorkspaceModel. In a sense, the ServerWorkspaceModel falls back to the basic WorkspaceModel on a disconnect.