### PR TITLE
Handle Lens STEP urls in reloadable

### DIFF
--- a/Utils.py
+++ b/Utils.py
@@ -8,8 +8,8 @@ import os
 import math
 import re
 import logging
-import tempfile
 
+from urllib.parse import urlparse
 import zipfile
 import shutil
 from contextlib import contextmanager
@@ -343,3 +343,35 @@ def wait_cursor():
         yield
     finally:
         QApplication.restoreOverrideCursor()
+
+
+def is_lens_url(url):
+    parsed_url_lens = urlparse(env.lens_url)
+    parsed_url = urlparse(url)
+
+    return (
+        parsed_url.scheme == parsed_url_lens.scheme
+        and parsed_url.netloc == parsed_url_lens.netloc
+    )
+
+
+def is_hex_digit(character):
+    return character in "0123456789abcdefABCDEF"
+
+
+def is_share_link(url):
+    if not is_lens_url(url):
+        return False
+
+    parsed_url = urlparse(url)
+    parts_path = parsed_url.path.split("/")
+    if len(parts_path) < 3:
+        return False
+
+    identifier = parts_path[-1]
+
+    return (
+        parts_path[-2] == "share"
+        and len(identifier) == 24
+        and all(is_hex_digit(c) for c in identifier)
+    )

--- a/integrations/reloadablefile/reloadable.py
+++ b/integrations/reloadablefile/reloadable.py
@@ -181,6 +181,12 @@ class ReloadableObject:
         if not self.is_valid_url(url):
             return
 
+        if Utils.is_share_link(url):
+            # Add suffix to get the step file directly
+            url = url + "/download"
+
+        logger.debug(f"url: {url}")
+
         try:
             response = requests.get(url)
             response.raise_for_status()

--- a/integrations/reloadablefile/taskpanel.ui
+++ b/integrations/reloadablefile/taskpanel.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Select a File or Enter a URL</string>
+   <string>Select a STEP file or enter a STEP URL</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
 
@@ -24,6 +24,9 @@
      <layout class="QHBoxLayout" name="horizontalLayoutSourceType">
       <item>
        <widget class="QRadioButton" name="radioButtonFile">
+        <property name="toolTip">
+         <string>Enable for a local STEP file</string>
+        </property>
         <property name="text">
          <string>Local File</string>
         </property>
@@ -34,6 +37,9 @@
       </item>
       <item>
        <widget class="QRadioButton" name="radioButtonURL">
+        <property name="toolTip">
+         <string>Enable for a STEP URL</string>
+        </property>
         <property name="text">
          <string>URL</string>
         </property>
@@ -46,33 +52,40 @@
    <!-- File Path input section -->
    <item>
     <widget class="QWidget" name="widgetFileInput">
-        <layout class="QHBoxLayout" name="horizontalLayoutFile">
-            <item>
-                <widget class="QLineEdit" name="lineEditFilePath"/>
-            </item>
-            <item>
-                <widget class="QPushButton" name="buttonBrowse">
-                    <property name="text">
-                        <string>...</string>
-                    </property>
-                </widget>
-            </item>
-        </layout>
+    <layout class="QHBoxLayout" name="horizontalLayoutFile">
+     <item>
+      <widget class="QLineEdit" name="lineEditFilePath">
+       <property name="toolTip">
+        <string>Choose a STEP file</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="buttonBrowse">
+       <property name="text">
+        <string>...</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
     </widget>
    </item>
 
    <!-- URL input section -->
    <item>
     <widget class="QWidget" name="widgetUrlInput">
-        <layout class="QHBoxLayout" name="horizontalLayoutURL">
-            <item>
-                <widget class="QLineEdit" name="lineEditUrl">
-                    <property name="placeholderText">
-                        <string>Enter URL</string>
-                    </property>
-                </widget>
-            </item>
-        </layout>
+    <layout class="QHBoxLayout" name="horizontalLayoutURL">
+     <item>
+      <widget class="QLineEdit" name="lineEditUrl">
+       <property name="toolTip">
+        <string>Enter a URL to a STEP file</string>
+       </property>
+       <property name="placeholderText">
+        <string>Enter URL</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
     </widget>
    </item>
 


### PR DESCRIPTION
Users can now use links such as
https://lens.ondsel.com/share/66c34c2cdde9e09b59078055 inside reloadables.